### PR TITLE
fix: Add rate limiting to DNS queries (Bug #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Test it by visiting a blocked domain like `https://doubleclick.net`
 - Support for multiple blocklist formats (hosts, domains, AdGuard)
 - Real-time rule updates from S3
 - Configurable upstream resolvers (Cloudflare, Google, custom)
+- **Rate limiting** to prevent DNS amplification attacks
 - Wildcard and regex support (planned)
 
 ### HTTPS Interception  
@@ -144,6 +145,8 @@ dns:
     - "8.8.8.8"         # Google
   cacheSize: 10000
   cacheTTL: "1h"
+  rateLimitQueries: 100  # Max queries per second per IP
+  rateLimitWindow: "1s"  # Rate limit time window
 
 # S3 rule management
 s3:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -147,7 +147,7 @@ func runAgent(opts *RunOptions) error {
 	}()
 
 	// Create DNS handler and server with API integration and captive portal support
-	handler := dns.NewHandler(blocker, cfg.DNS.Upstreams, "127.0.0.1", &cfg.CaptivePortal)
+	handler := dns.NewHandler(blocker, &cfg.DNS, "127.0.0.1", &cfg.CaptivePortal)
 	handler.SetStatsCallback(func(query bool, blocked bool, cached bool) {
 		if query {
 			apiServer.IncrementQueries()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,6 +20,10 @@ dns:
   # Cache settings
   cacheSize: 10000  # Number of entries to cache
   cacheTTL: "1h"    # How long to cache entries
+  
+  # Rate limiting (prevents DNS amplification attacks)
+  rateLimitQueries: 100  # Max queries per IP per window
+  rateLimitWindow: "1s"  # Time window for rate limiting
 
 # S3 configuration for centralized rule management
 s3:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,9 +54,11 @@ type S3Paths struct {
 }
 
 type DNSConfig struct {
-	Upstreams []string      `yaml:"upstreams"`
-	CacheSize int           `yaml:"cacheSize"`
-	CacheTTL  time.Duration `yaml:"cacheTTL"`
+	Upstreams        []string      `yaml:"upstreams"`
+	CacheSize        int           `yaml:"cacheSize"`
+	CacheTTL         time.Duration `yaml:"cacheTTL"`
+	RateLimitQueries int           `yaml:"rateLimitQueries"` // Queries per second per IP
+	RateLimitWindow  time.Duration `yaml:"rateLimitWindow"`  // Rate limit window
 }
 
 type BlockingConfig struct {
@@ -119,9 +121,11 @@ func LoadConfig(path string) (*Config, error) {
 			AllowDisable: true,
 		},
 		DNS: DNSConfig{
-			Upstreams: []string{"1.1.1.1", "8.8.8.8"},
-			CacheSize: 10000,
-			CacheTTL:  1 * time.Hour,
+			Upstreams:        []string{"1.1.1.1", "8.8.8.8"},
+			CacheSize:        10000,
+			CacheTTL:         1 * time.Hour,
+			RateLimitQueries: 100,          // 100 queries per second per IP
+			RateLimitWindow:  1 * time.Second,
 		},
 		Blocking: BlockingConfig{
 			DefaultAction: "block",

--- a/internal/dns/ratelimit.go
+++ b/internal/dns/ratelimit.go
@@ -1,0 +1,143 @@
+package dns
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// RateLimiter implements rate limiting for DNS queries
+type RateLimiter struct {
+	mu          sync.Mutex
+	clients     map[string]*clientInfo
+	maxQueries  int           // Max queries per window
+	window      time.Duration // Time window
+	cleanupTime time.Duration // How often to clean up old entries
+	lastCleanup time.Time
+}
+
+type clientInfo struct {
+	queries []time.Time
+}
+
+// NewRateLimiter creates a new DNS rate limiter
+func NewRateLimiter(maxQueries int, window time.Duration) *RateLimiter {
+	rl := &RateLimiter{
+		clients:     make(map[string]*clientInfo),
+		maxQueries:  maxQueries,
+		window:      window,
+		cleanupTime: 5 * time.Minute,
+		lastCleanup: time.Now(),
+	}
+	
+	// Start cleanup goroutine
+	go rl.cleanupRoutine()
+	
+	return rl
+}
+
+// Allow checks if a client is allowed to make a query
+func (rl *RateLimiter) Allow(clientIP net.IP) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	
+	// Get client key
+	key := clientIP.String()
+	
+	// Get or create client info
+	client, exists := rl.clients[key]
+	if !exists {
+		client = &clientInfo{
+			queries: make([]time.Time, 0, rl.maxQueries),
+		}
+		rl.clients[key] = client
+	}
+	
+	now := time.Now()
+	cutoff := now.Add(-rl.window)
+	
+	// Remove old queries outside the window
+	validQueries := make([]time.Time, 0, len(client.queries))
+	for _, queryTime := range client.queries {
+		if queryTime.After(cutoff) {
+			validQueries = append(validQueries, queryTime)
+		}
+	}
+	client.queries = validQueries
+	
+	// Check if limit exceeded
+	if len(client.queries) >= rl.maxQueries {
+		return false
+	}
+	
+	// Add current query
+	client.queries = append(client.queries, now)
+	return true
+}
+
+// GetClientRate returns the current query rate for a client
+func (rl *RateLimiter) GetClientRate(clientIP net.IP) int {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	
+	key := clientIP.String()
+	client, exists := rl.clients[key]
+	if !exists {
+		return 0
+	}
+	
+	now := time.Now()
+	cutoff := now.Add(-rl.window)
+	
+	count := 0
+	for _, queryTime := range client.queries {
+		if queryTime.After(cutoff) {
+			count++
+		}
+	}
+	
+	return count
+}
+
+// cleanup removes old client entries to prevent memory leak
+func (rl *RateLimiter) cleanup() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	
+	now := time.Now()
+	cutoff := now.Add(-rl.window * 2) // Keep entries for 2x the window
+	
+	for key, client := range rl.clients {
+		// Check if client has any recent queries
+		hasRecent := false
+		for _, queryTime := range client.queries {
+			if queryTime.After(cutoff) {
+				hasRecent = true
+				break
+			}
+		}
+		
+		// Remove if no recent queries
+		if !hasRecent {
+			delete(rl.clients, key)
+		}
+	}
+	
+	rl.lastCleanup = now
+}
+
+// cleanupRoutine runs periodic cleanup
+func (rl *RateLimiter) cleanupRoutine() {
+	ticker := time.NewTicker(rl.cleanupTime)
+	defer ticker.Stop()
+	
+	for range ticker.C {
+		rl.cleanup()
+	}
+}
+
+// Stop stops the rate limiter and cleans up resources
+func (rl *RateLimiter) Stop() {
+	// Cleanup will stop when the goroutine exits
+	// In a production implementation, we'd use a context for proper shutdown
+}

--- a/internal/dns/ratelimit_test.go
+++ b/internal/dns/ratelimit_test.go
@@ -1,0 +1,108 @@
+package dns
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestRateLimiter(t *testing.T) {
+	// Create rate limiter: 3 queries per 100ms
+	rl := NewRateLimiter(3, 100*time.Millisecond)
+	defer rl.Stop()
+	
+	clientIP := net.ParseIP("192.168.1.100")
+	
+	t.Run("AllowWithinLimit", func(t *testing.T) {
+		// First 3 queries should be allowed
+		for i := 0; i < 3; i++ {
+			if !rl.Allow(clientIP) {
+				t.Errorf("Query %d should be allowed", i+1)
+			}
+		}
+		
+		// 4th query should be denied
+		if rl.Allow(clientIP) {
+			t.Error("4th query should be denied")
+		}
+		
+		// Check rate
+		rate := rl.GetClientRate(clientIP)
+		if rate != 3 {
+			t.Errorf("Expected rate 3, got %d", rate)
+		}
+	})
+	
+	t.Run("AllowAfterWindow", func(t *testing.T) {
+		// Wait for window to expire
+		time.Sleep(150 * time.Millisecond)
+		
+		// Should allow queries again
+		if !rl.Allow(clientIP) {
+			t.Error("Query should be allowed after window expires")
+		}
+	})
+	
+	t.Run("DifferentClients", func(t *testing.T) {
+		client1 := net.ParseIP("10.0.0.1")
+		client2 := net.ParseIP("10.0.0.2")
+		
+		// Fill client1's quota
+		for i := 0; i < 3; i++ {
+			rl.Allow(client1)
+		}
+		
+		// Client2 should still be allowed
+		if !rl.Allow(client2) {
+			t.Error("Different client should have separate quota")
+		}
+		
+		// Client1 should be rate limited
+		if rl.Allow(client1) {
+			t.Error("Client1 should be rate limited")
+		}
+	})
+	
+	t.Run("Cleanup", func(t *testing.T) {
+		// Create many clients
+		for i := 0; i < 100; i++ {
+			ip := net.IPv4(192, 168, byte(i/256), byte(i%256))
+			rl.Allow(ip)
+		}
+		
+		// Wait for entries to become old
+		time.Sleep(300 * time.Millisecond)
+		
+		// Trigger cleanup
+		rl.cleanup()
+		
+		// Old entries should be removed
+		// (This is mainly to ensure cleanup doesn't panic)
+	})
+}
+
+func TestRateLimiterConcurrency(t *testing.T) {
+	rl := NewRateLimiter(100, time.Second)
+	defer rl.Stop()
+	
+	// Test concurrent access from multiple goroutines
+	done := make(chan bool)
+	
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			ip := net.IPv4(10, 0, 0, byte(id))
+			for j := 0; j < 50; j++ {
+				rl.Allow(ip)
+				time.Sleep(time.Millisecond)
+			}
+			done <- true
+		}(i)
+	}
+	
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+	
+	// If we get here without panic, concurrency is handled correctly
+}


### PR DESCRIPTION
## Summary
- Implemented per-IP rate limiting for DNS queries
- Prevents DNS amplification and DoS attacks
- Configurable limits with sensible defaults

## Changes
- Created `internal/dns/ratelimit.go` with:
  - Per-IP query tracking using sliding window
  - Automatic cleanup of old entries
  - Thread-safe implementation with mutex
- Updated `internal/dns/handler.go` to:
  - Check rate limits before processing queries
  - Return REFUSED for rate-limited clients
  - Log rate limit violations
- Added configuration options in `internal/config/config.go`:
  - `rateLimitQueries`: Max queries per window (default: 100)
  - `rateLimitWindow`: Time window (default: 1 second)
- Updated `config.example.yaml` with rate limit settings
- Added comprehensive tests in `ratelimit_test.go`
- Updated README documentation

## Security Improvements
- Prevents DNS amplification attacks
- Limits resource exhaustion from malicious clients
- Per-IP tracking prevents single bad actor from affecting others
- Graceful degradation with REFUSED responses

## Configuration
```yaml
dns:
  rateLimitQueries: 100  # Max queries per second per IP
  rateLimitWindow: "1s"  # Time window for rate limiting
```

## Test Plan
- [x] Unit tests pass for rate limiter
- [x] Code compiles without errors
- [ ] Test rate limiting with dig/nslookup
- [ ] Verify REFUSED responses for exceeded limits
- [ ] Test cleanup of old entries
- [ ] Verify legitimate traffic is not affected

🤖 Generated with [Claude Code](https://claude.ai/code)