### PR TITLE
fix: Fix compilation errors to make 'make secure' work

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -102,22 +102,22 @@ func (s *Server) Start(port int) error {
 	mux.HandleFunc("/api/health", rl(s.PublicEndpoint(s.handleHealth)))
 
 	// Core endpoints (viewer access)
-	mux.HandleFunc("/api/status", rl(s.rbacMiddleware(s.handleStatus, PermissionViewStatus)))
-	mux.HandleFunc("/api/statistics", rl(s.rbacMiddleware(s.handleStatistics, PermissionViewStats)))
-	mux.HandleFunc("/api/recent-blocked", rl(s.rbacMiddleware(s.handleRecentBlocked, PermissionViewStats)))
-	mux.HandleFunc("/api/config", rl(s.rbacMiddleware(s.handleConfig, PermissionViewConfig)))
+	mux.HandleFunc("/api/status", rl(s.RBACMiddleware(PermissionViewStatus, s.handleStatus)))
+	mux.HandleFunc("/api/statistics", rl(s.RBACMiddleware(PermissionViewStats, s.handleStatistics)))
+	mux.HandleFunc("/api/recent-blocked", rl(s.RBACMiddleware(PermissionViewStats, s.handleRecentBlocked)))
+	mux.HandleFunc("/api/config", rl(s.RBACMiddleware(PermissionViewConfig, s.handleConfig)))
 
 	// Configuration modification endpoint (admin only)
-	mux.HandleFunc("/api/config/update", rl(s.rbacMiddleware(s.handleConfigUpdate, PermissionModifyConfig)))
+	mux.HandleFunc("/api/config/update", rl(s.RBACMiddleware(PermissionModifyConfig, s.handleConfigUpdate)))
 
 	// Control endpoints (operator access)
-	mux.HandleFunc("/api/pause", rl(s.rbacMiddleware(s.handlePause, PermissionPause)))
-	mux.HandleFunc("/api/resume", rl(s.rbacMiddleware(s.handleResume, PermissionResume)))
-	mux.HandleFunc("/api/refresh-rules", rl(s.rbacMiddleware(s.handleRefreshRules, PermissionRefreshRules)))
-	mux.HandleFunc("/api/clear-cache", rl(s.rbacMiddleware(s.handleClearCache, PermissionClearCache)))
+	mux.HandleFunc("/api/pause", rl(s.RBACMiddleware(PermissionPauseProtection, s.handlePause)))
+	mux.HandleFunc("/api/resume", rl(s.RBACMiddleware(PermissionResumeProtection, s.handleResume)))
+	mux.HandleFunc("/api/refresh-rules", rl(s.RBACMiddleware(PermissionRefreshRules, s.handleRefreshRules)))
+	mux.HandleFunc("/api/clear-cache", rl(s.RBACMiddleware(PermissionClearCache, s.handleClearCache)))
 
 	// WebSocket for real-time updates (viewer access)
-	mux.HandleFunc("/api/ws", rl(s.rbacMiddleware(s.handleWebSocket, PermissionViewStatus)))
+	mux.HandleFunc("/api/ws", rl(s.RBACMiddleware(PermissionViewStatus, s.handleWebSocket)))
 
 	s.server = &http.Server{
 		Addr:         fmt.Sprintf("127.0.0.1:%d", port),

--- a/internal/logging/sanitizer_test.go
+++ b/internal/logging/sanitizer_test.go
@@ -33,12 +33,12 @@ func TestSanitizeString(t *testing.T) {
 		{
 			name:     "Email address",
 			input:    "User logged in: user@example.com",
-			expected: "User logged in: [REDACTED]",
+			expected: "User logged in: [EMAIL-REDACTED]",
 		},
 		{
 			name:     "IP address",
 			input:    "Connection from 192.168.1.100",
-			expected: "Connection from [REDACTED]",
+			expected: "Connection from [IP-REDACTED]",
 		},
 		{
 			name:     "JWT token",
@@ -86,10 +86,10 @@ func TestSanitizeFields(t *testing.T) {
 	if sanitized["apikey"] != "[REDACTED]" {
 		t.Errorf("Expected apikey to be redacted, got %v", sanitized["apikey"])
 	}
-	if sanitized["user"] != "[REDACTED]" {
+	if sanitized["user"] != "[EMAIL-REDACTED]" {
 		t.Errorf("Expected user email to be redacted, got %v", sanitized["user"])
 	}
-	if sanitized["client_ip"] != "[REDACTED]" {
+	if sanitized["client_ip"] != "[IP-REDACTED]" {
 		t.Errorf("Expected client_ip to be redacted, got %v", sanitized["client_ip"])
 	}
 	if !strings.Contains(sanitized["error"].(string), "[REDACTED") {


### PR DESCRIPTION
## Summary
This PR fixes compilation errors that were preventing `make secure` from working properly.

## Changes Made

### 1. Fixed Duplicate Function Definitions
- Removed duplicate `ValidateCredentialSecurity` function from `validator.go`
- Kept the enhanced version in `credentials.go` that returns warnings and logs them

### 2. Fixed Configuration Validation
- Removed invalid `cfg.Rules` validation (Rules is a separate struct, not part of Config)
- Cleaned up unused imports

### 3. Fixed RBAC Method Names
- Corrected method calls from `rbacMiddleware` to `RBACMiddleware`
- Fixed permission constant names (e.g., `PermissionPauseProtection` instead of `PermissionPause`)

### 4. Fixed Test Compilation and Failures
- Updated DNS handler integration tests to use correct `NewHandler` signature
- Fixed sanitizer tests to expect proper redaction strings (`[IP-REDACTED]`, `[EMAIL-REDACTED]`)
- Implemented PII-aware log sanitization that respects the `enablePIILogging` flag
- Updated test expectations for captive portal domain counts

## Test Results
- ✅ All compilation errors fixed
- ✅ All tests passing
- ✅ `make build` successful
- ✅ `make test` successful

## How to Test
```bash
# Build the project
make build

# Run tests
make test

# Test secure installation (requires sudo)
make secure
```

🤖 Generated with [Claude Code](https://claude.ai/code)