### PR TITLE
fix: Fix invalid duration format in config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -94,7 +94,7 @@ logging:
     enabled: false  # Set to true to enable S3 archival
     batchInterval: "1h"  # How often to upload logs to S3
     compression: "gzip"  # Compression format
-    retention: "90d"     # How long to retain logs
+    retention: "2160h"   # How long to retain logs (90 days)
   
   # Local buffering settings
   local:


### PR DESCRIPTION
## Summary
- Fixed invalid time duration format in config.example.yaml that was causing YAML unmarshal errors
- Changed `retention: "90d"` to `retention: "2160h"` (90 days = 2160 hours)

## Problem
When running `make secure` or any command that loads the config, it would fail with:
```
Error: failed to load config: yaml: unmarshal errors:
  line 97: cannot unmarshal \!\!str `90d` into time.Duration
```

## Solution
Go's `time.Duration` type doesn't support "d" suffix for days. It only supports:
- "h" for hours
- "m" for minutes  
- "s" for seconds
- "ms" for milliseconds
- "us" for microseconds
- "ns" for nanoseconds

Changed the retention field to use hours instead: 90 days × 24 hours/day = 2160 hours

## Testing
- The example config now loads without errors
- `make secure` command works properly

🤖 Generated with [Claude Code](https://claude.ai/code)